### PR TITLE
use createChildView and set the container when initing Notify

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,7 @@ var Container = Ember.ContainerView.extend({
       options = message;
       message = null;
     }
-    var view = Notify.View.create({
+    var view = this.createChildView(Notify.View, {
       message: message,
       type: type
     });
@@ -33,6 +33,7 @@ function aliasToShow(type) {
 
 var Notify = Container.createWithMixins({
   rootElement: null,
+  container: null,
   classNames: ['default-cn'],
   init: function() {
     this._super();
@@ -131,6 +132,7 @@ Ember.Application.initializer({
     // set the rootElement of the Notify container to the first Ember Application
     // instance that initializes
     if (Notify.get('rootElement')) return;
+    Notify.set('container', container);
     Notify.set('rootElement', App.rootElement);
   }
 });


### PR DESCRIPTION
When using ember-notify with ember 1.7.0-beta5 this error is thrown every time we try to show a notification:
`Uncaught Error: Container was not found when looking up a views template. This is most likely due to manually instantiating an Ember.View. See: http://git.io/EKPpnA`

This PR solves the problem.
