### PR TITLE
Allow change the default value for closeAfter in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ var message = Notify.alert('You can control how long it\'s displayed', {
 message.set('visible', false); // and you can hide messages programmatically.
 ```
 
+You can also change the default value for closing the notification in the template:
+
+
+```handlebars
+{{ember-notify closeAfter=4000}}
+```
+
 The Notify methods (`info`, `success`, `warning`, `alert` and `error`) all return a Promise for an instance of `Message`. You can use this object to change the `message` property, or to programatically hide the message by setting `visible` to `false`.
 
 You can specify raw HTML:

--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -5,6 +5,7 @@ import Message from 'ember-notify/message';
 export default Ember.Component.extend({
   source: null,
   messages: null,
+  closeAfter: 2500,
 
   classNames: ['ember-notify-cn'],
   messageStyle: 'foundation',
@@ -37,6 +38,7 @@ export default Ember.Component.extend({
 
 export var MessageView = Ember.View.extend({
   message: null,
+  closeAfter: undefined,
 
   classNames: ['ember-notify'],
   classNameBindings: ['typeCss', 'message.visible:ember-notify-show:ember-notify-hidden'],
@@ -61,7 +63,7 @@ export var MessageView = Ember.View.extend({
         this.set('message.visible', true);
       });
     }
-    var closeAfter = this.get('message.closeAfter');
+    var closeAfter = this.get('message.closeAfter') || this.get('closeAfter');
     if (closeAfter) {
       this.run.later(this, function() {
         if (this.get('isDestroyed')) return;

--- a/addon/message.js
+++ b/addon/message.js
@@ -4,6 +4,6 @@ export default Ember.Object.extend({
   message: null,
   raw: '',
   type: 'info',
-  closeAfter: 2500,
+  closeAfter: undefined,
   visible: undefined
 });

--- a/app/templates/components/ember-notify.hbs
+++ b/app/templates/components/ember-notify.hbs
@@ -1,5 +1,5 @@
 {{#each message in messages}}
-  {{#view view.messageClass message=message class='clearfix'}}
+  {{#view view.messageClass message=message closeAfter=closeAfter class='clearfix'}}
     <a {{action 'close' target='view'}} class='close'>&times;</a>
     <span class='message'>{{message.message}}{{{message.raw}}}</span>
   {{/view}}


### PR DESCRIPTION
This allow us to change the default time out that will close the message. So, I don't need to specify everywhere the `closeAfter`. If the `closeAfter` is present in the message, it will use that value instead of the default.