### PR TITLE
only show a notification if the component hasn't been destroyed

### DIFF
--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -31,7 +31,9 @@ export default Ember.Component.extend({
     if (!(message instanceof Message)) {
       message = Message.create(message);
     }
-    this.messages.pushObject(message);
+    if (!this.get('isDestroyed')) {
+      this.messages.pushObject(message);
+    }
     return message;
   }
 });


### PR DESCRIPTION
I ran into a problem when testing an application using `ember-notify` whereby `show` was getting called on a destroyed component. Since it seems there's no reason to ever queue messages if the component has been destroyed, I've added a conditional statement checking `isDestroyed`.