### PR TITLE
Fixed syntax error: ` instead of "

### DIFF
--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
       if ('foundation' === style) klass = FoundationView;
       else if ('bootstrap' === style) klass = BootstrapView;
       else throw new Error(
-        `Unknown messageStyle ${style}: options are 'foundation' and 'bootstrap'`
+        "Unknown messageStyle ${style}: options are 'foundation' and 'bootstrap'"
       );
     }
     this.set('messageClass', klass || this.constructor.defaultViewClass);


### PR DESCRIPTION
This small syntax error caused `uglifyJS` in my ember project to go haywire, and error was not too specific about which library. It was throwing error like this
```
Build failed.
Unexpected character '`'
Error
    at new JS_Parse_Error (/Users/dilip/Documents/Code/Portkey/node_modules/ember-cli-uglify/node_modules/broccoli-uglify-sourcemap/node_modules/uglify-js/lib/parse.js:196:18)
```
I knew some library got updated and broke the build, but didn't know which one.
It took me 4 hours to debug where the problem is. Finally found out that ember-notify is to blame. 