### PR TITLE
fix deprecation in ember canary

### DIFF
--- a/app/templates/components/ember-notify.hbs
+++ b/app/templates/components/ember-notify.hbs
@@ -1,4 +1,4 @@
-{{#each message in messages}}
+{{#each messages as |message|}}
   {{#view view.messageClass message=message closeAfter=closeAfter class='clearfix'}}
     <a {{action 'close' target='view'}} class='close'>&times;</a>
     <span class='message'>{{message.message}}{{{message.raw}}}</span>


### PR DESCRIPTION
DEPRECATION: Using the '{{#each item in model}}' form of the {{#each}} helper is deprecated. Please use the block param form instead ('{{#each model as |item|}}'). See http://emberjs.com/guides/deprecations/#toc_code-in-code-syntax-for-code-each-code for more details.