### PR TITLE
Adds "demoURL" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "demoURL": "http://aexmachina.info/assets/ember-demos/#/ember-notify"
   }
 }


### PR DESCRIPTION
Sites likes emberaddons.com and emberobserver.com will display a link to "demoURL".