### PR TITLE
adds support for thoughtbot's refills flashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `ember-notify` displays wee little notification messages down the bottom of your Ember.js app.
 
-The CSS classes are compatible with Zurb Foundation 5, or you can use Bootstrap styling using `{{ember-notify messageStyle='bootstrap'}}`.
+The CSS classes are compatible with Zurb Foundation 5, Thoughtbot's Refills, and Bootstrap. For Bootstrap use `{{ember-notify messageStyle='bootstrap'}}` and for Refills use `{{ember-notify messageStyle='refills'}}`.
 
 The CSS animations are inspired by CSS from [alertify.js](http://fabien-d.github.io/alertify.js/).
 

--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -20,6 +20,7 @@ export default Ember.Component.extend({
     if (style) {
       if ('foundation' === style) klass = FoundationView;
       else if ('bootstrap' === style) klass = BootstrapView;
+      else if ('refills' === style) klass = RefillsView;
       else throw new Error(
         `Unknown messageStyle ${style}: options are 'foundation' and 'bootstrap'`
       );
@@ -131,6 +132,21 @@ export var BootstrapView = MessageView.extend({
     var type = this.get('message.type');
     if (type === 'alert' || type === 'error') type = 'danger';
     return 'alert-' + type;
+  })
+});
+
+export var RefillsView = MessageView.extend({
+  typeCss: Ember.computed('type', function() {
+    var type = this.get('message.type');
+    var typeMapping = {
+      'success': 'success',
+      'alert': 'error',
+      'error': 'error',
+      'info': 'notice',
+      'warning': 'alert'
+    };
+
+    return 'flash-' + typeMapping[type];
   })
 });
 

--- a/tests/unit/ember-notify-test.js
+++ b/tests/unit/ember-notify-test.js
@@ -130,6 +130,25 @@ describeComponent('ember-notify', 'ember-notify', () => {
     expect($message.eq(1).is('.alert.alert-danger')).to.be.true();
   });
 
+  it('supports refills styling', function() {
+    var component = this.subject({
+      messageStyle: 'refills'
+    });
+    component.show({
+      message: 'Hello world'
+    });
+    component.show({
+      message: 'Hello again',
+      type: 'alert'
+    });
+    this.render();
+
+    var $el = component.$();
+    var $message = messages($el);
+    expect($message.eq(0).is('.flash-notice')).to.be.true();
+    expect($message.eq(1).is('.flash-error')).to.be.true();
+  });
+
   it('supports being provided an element', function() {
     var component = this.subject({});
     component.show({


### PR DESCRIPTION
Hey @aexmachina I'd like to add support for thoughtbot's [refills](http://refills.bourbon.io/components) flash stylings. Here's what the error message looks like:

![screen shot 2015-07-11 at 12 44 16 am](https://cloud.githubusercontent.com/assets/4792375/8632382/845a25d2-2766-11e5-80e9-67dba4ca7713.png)

Would you be willing to accept this PR? Thanks!