### PR TITLE
Moved object-assign to correct dependencies hash as dependencies was listed twice

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
     "node": ">= 0.10.0"
   },
   "license": "MIT",
-  "dependencies": {
-    "object-assign": "^2.0.0"
-  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
     "ember-cli": "1.13.6",
@@ -41,6 +38,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "object-assign": "^2.0.0",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "0.7.9"
   },


### PR DESCRIPTION
related to https://github.com/aexmachina/ember-notify/issues/54#issuecomment-129957857