### PR TITLE
Clear deprecation warning for initializer :snowboarder:

### DIFF
--- a/addon/initializer.js
+++ b/addon/initializer.js
@@ -1,4 +1,5 @@
-export function initialize(container, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
   application.inject('route', 'notify', 'service:notify');
   application.inject('controller', 'notify', 'service:notify');
 }


### PR DESCRIPTION
Starting with Ember 2.1 providing two arguments to an initializer
will trigger a deprecation.
Read more : http://emberjs.com/deprecations/v2.x/#toc_initializer-arity