### PR TITLE
Add support for Ember.Handlebars.SafeString

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -20,6 +20,10 @@ var Notify = Ember.Service.extend({
   },
 
   show(type, text, options) {
+    // If the text passed is `SafeString`, convert it
+    if (text instanceof Ember.Handlebars.SafeString) {
+      text = text.toString();
+    }
     if (typeof text === 'object') {
       options = text;
       text = null;

--- a/tests/unit/components/ember-notify-test.js
+++ b/tests/unit/components/ember-notify-test.js
@@ -88,6 +88,21 @@ describeComponent(
       expect($message.is('.' + level)).to.be.true;
     }
 
+    it('can render messages with SafeString', function() {
+      var component = this.subject();
+      component.show({
+        text: new Ember.Handlebars.SafeString('Hello world'),
+        type: 'info'
+      });
+      this.render();
+
+      var $el = component.$();
+      var $message = messages($el);
+      expect($el.length).to.equal(1, 'component is added');
+      expect($message.length).to.equal(1, 'element is added');
+      expect($message.find('.message').text()).to.equal('Hello world');
+    });
+
     it('can be shown manually', function() {
       var component = this.subject();
       var message = component.show({


### PR DESCRIPTION
* Previously, `text` would get confused with `options` if notify was sent text marked as safe by ember (e.g. from an ember-i18n translation)
* If `text` is a subclass of `SafeString`, call `toString` to render the safestring to a string, then resume
* Added a test as well
* Refs #62 