### PR TITLE
#69 validate state before proxying close action

### DIFF
--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -2,6 +2,10 @@ import Ember from 'ember';
 import layout from '../../templates/components/ember-notify/message';
 import Notify from 'ember-notify';
 
+function checkSendCloseIntent() {
+  if (this.get('isDestroyed')) return;
+  this.send('closeIntent');
+}
 export default Ember.Component.extend({
   layout: layout,
   message: null,
@@ -35,10 +39,7 @@ export default Ember.Component.extend({
     var closeAfter = this.get('message.closeAfter');
     if (closeAfter === undefined) closeAfter = this.get('closeAfter');
     if (closeAfter) {
-      this.run.later(this, function() {
-        if (this.get('isDestroyed')) return;
-        this.send('closeIntent');
-      }, closeAfter);
+      this.run.later(this, checkSendCloseIntent, closeAfter);
     }
   },
   themeClassNames: Ember.computed('theme', 'message.type', function() {
@@ -58,9 +59,7 @@ export default Ember.Component.extend({
   	// alias to close action so we can poll whether hover state is active
   	closeIntent: function() {
     	if (this.isHovering()) {
-    		return this.run.later(() => {
-    			this.send('closeIntent');
-    		}, 100);
+    		return this.run.later(this, checkSendCloseIntent, 100);
     	}
     	// when :hover no longer applies, close as normal
 	    this.send('close');
@@ -80,7 +79,6 @@ export default Ember.Component.extend({
         var parentView = this.get('parentView');
         if (this.get('isDestroyed') || !parentView || !parentView.get('messages')) return;
         parentView.get('messages').removeObject(this.get('message'));
-        this.set('message.visible', null);
       }
     }
   }

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -48,7 +48,7 @@ export default Ember.Component.extend({
     }
   }),
   isHovering: function() {
-  	return this.$().is(':hover');
+    return this.$().is(':hover');
   },
 
   actions: {

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -79,6 +79,7 @@ export default Ember.Component.extend({
         var parentView = this.get('parentView');
         if (this.get('isDestroyed') || !parentView || !parentView.get('messages')) return;
         parentView.get('messages').removeObject(this.get('message'));
+      	this.set('message.visible', null);
       }
     }
   }

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -56,11 +56,7 @@ export default Ember.Component.extend({
   	closeIntent: function() {
       if (this.get('isDestroyed')) return;
     	if (this.isHovering()) {
-<<<<<<< Updated upstream
-    		return this.run.later(this, checkSendCloseIntent, 100);
-=======
     		return this.run.later(() => { this.send('closeIntent'); }, 100);
->>>>>>> Stashed changes
     	}
     	// when :hover no longer applies, close as normal
 	    this.send('close');

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -2,10 +2,6 @@ import Ember from 'ember';
 import layout from '../../templates/components/ember-notify/message';
 import Notify from 'ember-notify';
 
-function checkSendCloseIntent() {
-  if (this.get('isDestroyed')) return;
-  this.send('closeIntent');
-}
 export default Ember.Component.extend({
   layout: layout,
   message: null,
@@ -39,7 +35,7 @@ export default Ember.Component.extend({
     var closeAfter = this.get('message.closeAfter');
     if (closeAfter === undefined) closeAfter = this.get('closeAfter');
     if (closeAfter) {
-      this.run.later(this, checkSendCloseIntent, closeAfter);
+      this.run.later(() => { this.send('closeIntent'); }, closeAfter);
     }
   },
   themeClassNames: Ember.computed('theme', 'message.type', function() {
@@ -58,8 +54,13 @@ export default Ember.Component.extend({
   actions: {
   	// alias to close action so we can poll whether hover state is active
   	closeIntent: function() {
+      if (this.get('isDestroyed')) return;
     	if (this.isHovering()) {
+<<<<<<< Updated upstream
     		return this.run.later(this, checkSendCloseIntent, 100);
+=======
+    		return this.run.later(() => { this.send('closeIntent'); }, 100);
+>>>>>>> Stashed changes
     	}
     	// when :hover no longer applies, close as normal
 	    this.send('close');

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -76,7 +76,7 @@ export default Ember.Component.extend({
         var parentView = this.get('parentView');
         if (this.get('isDestroyed') || !parentView || !parentView.get('messages')) return;
         parentView.get('messages').removeObject(this.get('message'));
-      	this.set('message.visible', null);
+        this.set('message.visible', null);
       }
     }
   }

--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -35,7 +35,7 @@ export default Ember.Component.extend({
     var closeAfter = this.get('message.closeAfter');
     if (closeAfter === undefined) closeAfter = this.get('closeAfter');
     if (closeAfter) {
-      this.run.later(() => { this.send('closeIntent'); }, closeAfter);
+      this.run.later(() => this.send('closeIntent'), closeAfter);
     }
   },
   themeClassNames: Ember.computed('theme', 'message.type', function() {
@@ -52,15 +52,15 @@ export default Ember.Component.extend({
   },
 
   actions: {
-  	// alias to close action so we can poll whether hover state is active
-  	closeIntent: function() {
+    // alias to close action so we can poll whether hover state is active
+    closeIntent: function() {
       if (this.get('isDestroyed')) return;
-    	if (this.isHovering()) {
-    		return this.run.later(() => { this.send('closeIntent'); }, 100);
-    	}
-    	// when :hover no longer applies, close as normal
-	    this.send('close');
-  	},
+      if (this.isHovering()) {
+        return this.run.later(() => this.send('closeIntent'), 100);
+      }
+      // when :hover no longer applies, close as normal
+      this.send('close');
+    },
     close: function() {
       if (this.get('message.closed')) return;
       this.set('message.closed', true);

--- a/tests/unit/components/ember-notify-test.js
+++ b/tests/unit/components/ember-notify-test.js
@@ -47,7 +47,7 @@ describeComponent(
       expect($message.is('.info')).to.be.true;
       expect($message.find('.message').text()).to.equal('Hello world');
 
-      return observeSequence(message, 'visible', [false, null])
+      return observeSequence(message, 'visible', [false])
         .then(observed => Ember.run.next(() => {
           expect(messages($el).length).to.equal(0, 'element is removed from DOM');
           var times = timesSince(observed, start);
@@ -119,7 +119,7 @@ describeComponent(
       expect($message.is('.ember-notify-show')).to.equal(true, 'message is shown');
     });
 
-    it('can be hidden manually', function() {
+    it('can be hidden manually', function(done) {
       var start = new Date();
       var component = this.subject();
       var message = component.show({
@@ -131,12 +131,15 @@ describeComponent(
 
       var $el = component.$();
       expect(messages($el).length).to.equal(1, 'element is added');
-      message.set('visible', false);
-      return observeSequence(message, 'visible', [null])
+      Ember.run(() => {
+				message.set('visible', false);
+			});
+      observeSequence(message, 'visible', [null])
         .then(observed => Ember.run.next(() => {
           expect(messages($el).length).to.equal(0, 'element is removed from DOM');
           var times = timesSince(observed, start);
           expect(times[0]).to.be.greaterThan(100);
+					done();
         }));
     });
 

--- a/tests/unit/components/ember-notify-test.js
+++ b/tests/unit/components/ember-notify-test.js
@@ -131,15 +131,13 @@ describeComponent(
 
       var $el = component.$();
       expect(messages($el).length).to.equal(1, 'element is added');
-      Ember.run(() => {
-				message.set('visible', false);
-			});
+      Ember.run(() => message.set('visible', false) );
       observeSequence(message, 'visible', [null])
         .then(observed => Ember.run.next(() => {
           expect(messages($el).length).to.equal(0, 'element is removed from DOM');
           var times = timesSince(observed, start);
           expect(times[0]).to.be.greaterThan(100);
-					done();
+          done();
         }));
     });
 
@@ -209,17 +207,16 @@ describeComponent(
       expect(component.$('.message input').length).to.equal(1);
     });
     it(`defaults to using the 'ember-notify-default' CSS class`, function() {
-      var component = this.subject({
-			});
+      var component = this.subject({});
       component.show({});
 
       this.render();
       expect(component.$().attr('class')).to.contain('ember-notify-default');
-		});
+    });
     it('supports customizing the base CSS class', function() {
       var component = this.subject({
-				classPrefix: 'foo'
-			});
+        classPrefix: 'foo'
+      });
       component.show({});
 
       this.render();


### PR DESCRIPTION
Without checking if the component is being destroyed, the `this.$()`
will return null and set will later be called on a destroyed message
object.