### PR TITLE
custom message markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 `ember-notify` displays wee little notification messages down the bottom of your Ember.js app.
 
 ### Compatibility
- 
+
 ember-notify is compatible with the following presentation frameworks:
 
 - Zurb Foundation (default)
@@ -22,7 +22,7 @@ The CSS animations are inspired by CSS from [alertify.js](http://fabien-d.github
 1. Add `{{ember-notify}}` to one of your templates, usually in `application.hbs`
 2. Inject the `notify` service
 3. Display messages using the `info`, `success`, `warning`, `alert` and `error` methods
- 
+
 ### Examples
 
 ```js
@@ -86,12 +86,12 @@ export {default} from 'ember-notify/initializer';
 
 ### Multiple Containers
 
-If you want to have separate notifications and control where they're inserted into the DOM you can 
+If you want to have separate notifications and control where they're inserted into the DOM you can
 have multiple `{{ember-notify}}` components, but only one of them can be accessed using the injected service.
 The others you will need to provide a `source` property, so secondary containers should be used as follows:
 
 ```hbs
-{{ember-notify source=someProperty}} 
+{{ember-notify source=someProperty}}
 ```
 
 ```js
@@ -104,7 +104,19 @@ export default Ember.Component.extend({
   }
 });
 ```
-### Custom Animations 
+### Custom message template
+You can pass a block with template you wanna be used for each message (instead of using the default one). It may look like this:
+```hbs
+  {{#ember-notify as |message close|}}
+    <a {{action close}} class='close'>close from block</a>
+    <span class='message-from-block'>{{message.text}}</span>
+  {{/ember-notify}}
+```
+Two arguments are passed to the block: `message` object, and `close` action. Make sure
+you are using *Closure Actions* syntax passing the action (e. g. `<a {{action close}}` or
+`{{your-component close=(action close)`.
+
+### Custom Animations
 By default, the `ember-notify` message window will appear from the bottom right corner of the screen.  You may want to control the postioning or animations.
 To do so, you need to pass a CSS class name using the `classPrefix` option. This will render the top level `ember-notify` element with the class you pass in.
 

--- a/addon/templates/components/ember-notify.hbs
+++ b/addon/templates/components/ember-notify.hbs
@@ -1,4 +1,20 @@
 {{#each messages as |message|}}
-  {{ember-notify/message
-      message=message theme=theme closeAfter=closeAfter class='ember-notify clearfix'}}
+  {{#if hasBlock}}
+    {{#ember-notify/message
+       message=message
+       theme=theme
+       closeAfter=closeAfter
+       class='ember-notify clearfix'
+       as |message close|
+    }}
+      {{yield message close}}
+    {{/ember-notify/message}}
+  {{else}}
+    {{ember-notify/message
+      message=message
+      theme=theme
+      closeAfter=closeAfter
+      class='ember-notify clearfix'
+    }}
+  {{/if}}
 {{/each}}

--- a/addon/templates/components/ember-notify/message.hbs
+++ b/addon/templates/components/ember-notify/message.hbs
@@ -1,2 +1,6 @@
-<a {{action 'close'}} class='close'>&times;</a>
-<span class='message'>{{message.text}}{{{message.html}}}</span>
+{{#if hasBlock}}
+  {{yield message (action 'close')}}
+{{else}}
+  <a {{action 'close'}} class='close'>&times;</a>
+  <span class='message'>{{message.text}}{{{message.html}}}</span>
+{{/if}}

--- a/tests/integration/components/ember-notify-test.js
+++ b/tests/integration/components/ember-notify-test.js
@@ -1,0 +1,38 @@
+/* jshint expr:true */
+import Ember from 'ember';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import Notify from 'ember-notify';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent(
+  'ember-notify',
+  'EmberNotifyComponent | Integration',
+  {
+    integration: true
+  },
+  function() {
+    before(() => Notify.testing = true);
+    after(() => Notify.testing = false);
+
+    it('renders block version', function() {
+      this.render(hbs`
+        {{#ember-notify messages=messages as |message close|}}
+          <a {{action close}} class='close-from-block'>CLOSE</a>
+          <span class='message-from-block'>{{message.text}}</span>
+        {{/ember-notify}}
+      `);
+
+      const dummyMessage = Ember.Object.create({text: 'dummy text', visible: true, type: 'alert'});
+      this.set('messages', [ dummyMessage ]);
+
+      // ensure block is yielded
+      expect(this.$().find('.message-from-block').text()).to.equal('dummy text');
+      // close action is passed
+      this.$().find('.close-from-block').click();
+      expect(dummyMessage.get('visible')).to.be.false;
+    });
+  }
+);

--- a/tests/integration/components/ember-notify/message-test.js
+++ b/tests/integration/components/ember-notify/message-test.js
@@ -1,0 +1,42 @@
+/* jshint expr:true */
+import Ember from 'ember';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import Notify from 'ember-notify';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent(
+  'ember-notify/message',
+  'EmberNotifyMessageComponent | Integration',
+  {
+    integration: true
+  },
+  function() {
+    before(() => Notify.testing = true);
+    after(() => Notify.testing = false);
+
+    it('renders block version', function() {
+      const dummyMessage = Ember.Object.create({
+        text: 'dummy text',
+        visible: true
+      });
+      this.set('message', dummyMessage);
+
+      // Template block usage:
+      this.render(hbs`
+        {{#ember-notify/message message=message as |message close|}}
+          <a {{action close}} class='close-from-block'>CLOSE</a>
+          <span class='message-from-block'>{{message.text}}</span>
+        {{/ember-notify/message}}
+      `);
+
+      // ensure block is yielded
+      expect(this.$().find('.message-from-block').text()).to.equal('dummy text');
+      // close action is passed
+      this.$().find('.close-from-block').click();
+      expect(dummyMessage.get('visible')).to.be.false;
+    });
+  }
+);


### PR DESCRIPTION
This PR adds the support of using arbitrary markup in messages (in case you wanna use a dedicated icon for close etc):

```handlebars
{{#ember-notify messageStyle='bootstrap' class="notification" as |message close|}}
     {{! what about using a button for closing the message ? }}
    <input class="close" type="button" value="close" {{action close}}>
    <span class='message'>{{message.text}}</span>
  {{/ember-notify}}
```