### PR TITLE
Changed notify container from alert-box to callout for Foundation 6

### DIFF
--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -65,7 +65,7 @@ export var Theme = Ember.Object.extend({
 export var FoundationTheme = Theme.extend({
   classNamesFor(message) {
     var type = message.get('type');
-    var classNames = ['alert-box', type];
+    var classNames = ['callout', type];
     if (type === 'error') classNames.push('alert');
     return classNames.join(' ');
   }


### PR DESCRIPTION
Ember notify is not working with foundation 6. Fixed, no backward compatibility for foundation 5.