### PR TITLE
Remove demoURL key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "ember-cli-htmlbars": "0.7.9"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
-    "demoURL": "http://aexmachina.info/assets/ember-demos/#/ember-notify"
+    "configPath": "tests/dummy/config"
   }
 }


### PR DESCRIPTION
The page in the `demoURL` key doesn't link to a demo, so remove the key.