### PR TITLE
Fix Ember.merge deprecation: use Ember.assign if it is available

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -20,6 +20,8 @@ var Notify = Ember.Service.extend({
   },
 
   show(type, text, options) {
+    var assign = Ember.assign || Ember.merge;
+
     // If the text passed is `SafeString`, convert it
     if (text instanceof Ember.Handlebars.SafeString) {
       text = text.toString();
@@ -28,7 +30,7 @@ var Notify = Ember.Service.extend({
       options = text;
       text = null;
     }
-    var message = Message.create(Ember.merge({
+    var message = Message.create(assign({
       text: text,
       type: type
     }, options));

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -4,9 +4,10 @@ import config from '../../config/environment';
 
 export default function startApp(attrs) {
   var application;
+  var assign = Ember.assign || Ember.merge;
 
-  var attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+  var attributes = assign({}, config.APP);
+  attributes = assign(attributes, attrs); // use defaults, but you can override;
 
   Ember.run(function() {
     application = Application.create(attributes);


### PR DESCRIPTION
In ember >= v2.5.0 `ember-notify` throw a deprecation:
> Usage of `Ember.merge` is deprecated, use `Ember.assign` instead.

It's occurs because Ember.merge will be removed in ember#3.0.0: [link to blog](http://emberjs.com/deprecations/v2.x/#toc_ember-merge).

I add `assign` variable, which equals to Ember.assign (for ember >= 2.1.0) or Ember.merge (for oldest ember versions).