### PR TITLE
Replace Ember.Handlebars.SafeString to Ember.String.htmlSafe

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -23,7 +23,7 @@ var Notify = Ember.Service.extend({
     var assign = Ember.assign || Ember.merge;
 
     // If the text passed is `SafeString`, convert it
-    if (text instanceof Ember.Handlebars.SafeString) {
+    if (text instanceof Ember.String.htmlSafe) {
       text = text.toString();
     }
     if (typeof text === 'object') {

--- a/tests/unit/components/ember-notify-test.js
+++ b/tests/unit/components/ember-notify-test.js
@@ -91,7 +91,7 @@ describeComponent(
     it('can render messages with SafeString', function() {
       var component = this.subject();
       component.show({
-        text: new Ember.Handlebars.SafeString('Hello world'),
+        text: new Ember.String.htmlSafe('Hello world'),
         type: 'info'
       });
       this.render();


### PR DESCRIPTION
Resolves the deprecation notification for `Ember.Handlebars.SafeString` issue as described in aexmachina/ember-notify#92

You can learn more about it here http://emberjs.com/blog/2016/09/08/ember-2-8-and-2-9-beta-released.html#toc_code-ember-string-ishtmlsafe-code