### PR TITLE
add ember-string-ishtmlsafe-polyfill to fix detection of safe strings

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import Message from './message';
+import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 function aliasToShow(type) {
   return function(message, options) {
@@ -23,7 +24,7 @@ var Notify = Ember.Service.extend({
     var assign = Ember.assign || Ember.merge;
 
     // If the text passed is `SafeString`, convert it
-    if (text instanceof Ember.String.htmlSafe) {
+    if (isHTMLSafe(text)) {
       text = text.toString();
     }
     if (typeof text === 'object') {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "dependencies": {
     "object-assign": "^2.0.0",
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "^1.0.3"
+    "ember-cli-htmlbars": "^1.0.3",
+    "ember-string-ishtmlsafe-polyfill": "1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
which is now the recommended way http://emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring, the polyfill uses the Ember.String.isHTMLSafe method available in ember 2.8+ or falls back to polyfilling if on older ember versions (https://github.com/workmanw/ember-string-ishtmlsafe-polyfill)
