### PR TITLE
Fixed the SafeString check

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -23,7 +23,7 @@ var Notify = Ember.Service.extend({
     var assign = Ember.assign || Ember.merge;
 
     // If the text passed is `SafeString`, convert it
-    if (text instanceof Ember.String.htmlSafe) {
+    if (Ember.String.isHTMLSafe(text)) {
       text = text.toString();
     }
     if (typeof text === 'object') {


### PR DESCRIPTION
Use `Ember.String.isHTMLSafe()` to do the SafeString check as discussed here https://github.com/emberjs/ember.js/issues/13318