### PR TITLE
Update isHTMLSafe polyfill dep

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,5 @@
 import Ember from 'ember';
 import Message from './message';
-import isHTMLSafe from 'ember-string-ishtmlsafe-polyfill';
 
 function aliasToShow(type) {
   return function(message, options) {
@@ -24,7 +23,7 @@ var Notify = Ember.Service.extend({
     var assign = Ember.assign || Ember.merge;
 
     // If the text passed is `SafeString`, convert it
-    if (isHTMLSafe(text)) {
+    if (Ember.String.isHTMLSafe(text)) {
       text = text.toString();
     }
     if (typeof text === 'object') {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.3",
-    "ember-string-ishtmlsafe-polyfill": "1.0.1",
+    "ember-string-ishtmlsafe-polyfill": "^1.1.0",
     "object-assign": "^4.1.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Latest release places the polyfill in the “native” location, instead of needing to import the function.

Note: This is part of an effort to get all users of the polyfill updated.. workmanw/ember-string-ishtmlsafe-polyfill#5