### PR TITLE
Option to disable :hover state monitoring

### DIFF
--- a/addon/components/ember-notify/message.js
+++ b/addon/components/ember-notify/message.js
@@ -56,7 +56,7 @@ export default Ember.Component.extend({
     // alias to close action so we can poll whether hover state is active
     closeIntent: function() {
       if (this.get('isDestroyed')) return;
-      if (this.isHovering()) {
+      if (!this.get('message.ignoreHover') && this.isHovering()) {
         return this.run.later(() => this.send('closeIntent'), 100);
       }
       // when :hover no longer applies, close as normal

--- a/addon/message.js
+++ b/addon/message.js
@@ -6,5 +6,6 @@ export default Ember.Object.extend({
   type: 'info',
   closeAfter: undefined,
   visible: undefined,
+  ignoreHover: undefined,
   classNames: []
 });


### PR DESCRIPTION
I faced an slight issue on a touch screen, where any touch on a component sets :hover state to it until any other area is touched. Here is a PR with an option to disable hover state monitoring for such cases.