### PR TITLE
Update repository for the addon to be transferred

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[<img align='right' alt='Build Status' src='https://travis-ci.org/aexmachina/ember-notify.png'>](https://travis-ci.org/aexmachina/ember-notify)
+[<img align='right' alt='Build Status' src='https://travis-ci.org/adopted-ember-addons/ember-notify.png'>](https://travis-ci.org/adopted-ember-addons/ember-notify)
 
 # ember-notify
 
@@ -178,7 +178,7 @@ npm install ember-notify --save-dev
 
 ### Upgrading from a previous version
 
-See [the CHANGELOG](https://github.com/aexmachina/ember-notify/blob/master/CHANGELOG.md).
+See [the CHANGELOG](https://github.com/adopted-ember-addons/ember-notify/blob/master/CHANGELOG.md).
 
 ## Browser Compatibility
 

--- a/package.json
+++ b/package.json
@@ -1,17 +1,17 @@
 {
   "name": "ember-notify",
   "version": "5.2.1",
-  "description": "The default blueprint for ember-cli addons.",
+  "description": "Easy, wee little notifications",
   "keywords": [
     "ember-addon"
   ],
   "license": "MIT",
-  "author": "",
+  "author": "Simon Wade",
   "directories": {
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/adopted-ember-addons/ember-notify",
   "scripts": {
     "build": "ember build",
     "lint:js": "eslint ./*.js addon addon-test-support app blueprints config lib server test-support tests",


### PR DESCRIPTION
Transferring to `adopted-ember-addons`.

Closes #129.

@aexmachina there are a few steps to be completed on your side:
https://github.com/adopted-ember-addons/program-guidelines

Thanks!

