### PR TITLE
use create rather then property when adding multiple containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ import Notify from 'ember-notify';
 import { action } from '@ember/object';
 
 export default class MyComponent extends Component {
-  alternativeNotify = Notify.property();
+  alternativeNotify = Notify.create();
 
   @action
   clicked() {


### PR DESCRIPTION
Using property would throw the error:
```
Uncaught Error: Assertion Failed: EmberObject.create no longer supports defining computed properties. Define computed properties using extend() or reopen() before calling create().
```
While instead using `create()` seems to fix the issue.
