### PR TITLE
embroider: fix invalid CSS warning

### DIFF
--- a/vendor/ember-notify.css
+++ b/vendor/ember-notify.css
@@ -91,10 +91,6 @@
   }
 }
 
-.ember-notify-cn .clearfix {
-  *zoom: 1;
-}
-
 .ember-notify-cn .clearfix::before,
 .ember-notify-cn .clearfix::after {
   content: " ";


### PR DESCRIPTION
I do not understand what the `*zoom` syntax should do but seem to recall it is the CSS clearfix trick.
Close #200.