### PR TITLE
Fix importing `inject` from `@ember/service` deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## UNRELEASED
+  - Fix importing `inject` from `@ember/service` deprecation warning
+
 ### BREAKING CHANGES
   - Messages can be programmatically closed by doing `message.close()`. Changing the `visible` property was broken.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The CSS animations are inspired by CSS from [alertify.js](http://fabien-d.github
 
 ```js
 import Component from '@glimmer/component';
-import { inject as service } from '@ember/service';
+import { service } from '@ember/service';
 import { action } from '@ember/object';
 
 export default class MyComponent extends Component {

--- a/addon/components/ember-notify.js
+++ b/addon/components/ember-notify.js
@@ -1,10 +1,13 @@
 import { A } from '@ember/array';
 import { computed } from '@ember/object';
 import { oneWay } from '@ember/object/computed';
-import { inject as service } from '@ember/service';
+import * as emberService from '@ember/service';
 import Component from '@ember/component';
 import layout from '../templates/components/ember-notify';
 import Message from 'ember-notify/message';
+
+// Preserve backward compatibility with Ember versions prior to 4.1
+const service = emberService.service ?? emberService.inject;
 
 export default Component.extend({
   layout,


### PR DESCRIPTION
Fixes https://github.com/adopted-ember-addons/ember-notify/issues/202

@SergeAstapov I kept backward compatibility with Ember versions prior to 4.1, since I wasn’t sure how far back this library is expected to support.